### PR TITLE
Fix Angular polyfills

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -14,7 +14,9 @@
             "outputPath": "dist/online-order-platform",
             "index": "src/index.html",
             "main": "src/main.ts",
-            "polyfills": [],
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "tsconfig.json",
             "assets": [
               "src/favicon.ico",


### PR DESCRIPTION
## Summary
- ensure Zone.js polyfill loads when building the Angular app

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a20ebfe5083228f49ed7872cb635b