### PR TITLE
Improve food ordering UX

### DIFF
--- a/src/app/components/header/header.component.css
+++ b/src/app/components/header/header.component.css
@@ -3,6 +3,13 @@ header {
   color: #fff;
   padding: 1rem;
 }
+
+nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
 nav a {
   color: #fff;
   margin-right: 1rem;

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,6 +1,6 @@
 <header>
   <nav>
     <a routerLink="/">Home</a>
-    <a routerLink="/cart">Cart</a>
+    <a routerLink="/cart">Cart ({{ cartService.items.length }})</a>
   </nav>
 </header>

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,8 +1,11 @@
 import { Component } from '@angular/core';
+import { CartService } from '../../services/cart.service';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css']
 })
-export class HeaderComponent {}
+export class HeaderComponent {
+  constructor(public cartService: CartService) {}
+}

--- a/src/app/components/product-list/product-list.component.css
+++ b/src/app/components/product-list/product-list.component.css
@@ -1,14 +1,20 @@
 .products {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
 }
 .product {
   border: 1px solid #ddd;
   padding: 1rem;
-  margin: 0.5rem;
-  width: 200px;
+  background: #fff;
 }
 .product img {
   width: 100%;
   height: auto;
+}
+
+@media (max-width: 600px) {
+  .product {
+    padding: 0.5rem;
+  }
 }

--- a/src/app/components/product-list/product-list.component.ts
+++ b/src/app/components/product-list/product-list.component.ts
@@ -23,5 +23,6 @@ export class ProductListComponent implements OnInit {
 
   addToCart(product: Product): void {
     this.cartService.addToCart(product);
+    alert('Added to cart');
   }
 }

--- a/src/app/mock/products.ts
+++ b/src/app/mock/products.ts
@@ -3,29 +3,29 @@ import { Product } from '../models/product';
 export const products: Product[] = [
   {
     id: '1',
-    name: 'Smartphone',
-    description: 'Latest model smartphone',
-    fullDescription: 'Full description of smartphone',
-    price: 699,
-    category: 'Electronics',
+    name: 'Cheese Pizza',
+    description: 'Classic cheese pizza',
+    fullDescription: 'A delicious pizza topped with rich tomato sauce and mozzarella cheese.',
+    price: 12.5,
+    category: 'Pizza',
     image: 'assets/placeholder.png'
   },
   {
     id: '2',
-    name: 'Novel Book',
-    description: 'A great novel',
-    fullDescription: 'Full description of novel',
-    price: 19.99,
-    category: 'Books',
+    name: 'Veggie Burger',
+    description: 'Grilled veggie patty with fresh toppings',
+    fullDescription: 'A hearty burger made with a grilled vegetable patty, lettuce, tomato and a soft bun.',
+    price: 9.99,
+    category: 'Burgers',
     image: 'assets/placeholder.png'
   },
   {
     id: '3',
-    name: 'T-Shirt',
-    description: 'Comfortable cotton t-shirt',
-    fullDescription: 'Full description of t-shirt',
-    price: 25,
-    category: 'Apparel',
+    name: 'Caesar Salad',
+    description: 'Crisp romaine with Caesar dressing',
+    fullDescription: 'Fresh romaine lettuce tossed with creamy Caesar dressing, croutons and parmesan.',
+    price: 8.5,
+    category: 'Salads',
     image: 'assets/placeholder.png'
   }
 ];

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>OnlineOrderPlatform</title>
+  <title>Food Order App</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>


### PR DESCRIPTION
## Summary
- show cart item count in header
- use a responsive grid for products
- add sample food products
- alert when adding to cart
- retitle app to "Food Order App"

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a2b496b4c8322b50802980de6bf0a