### PR TITLE
Add login and table selection flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@angular/router": "^17.0.0",
     "rxjs": "^7.8.0",
     "tslib": "^2.6.0",
-    "zone.js": "^0.13.0"
+    "zone.js": "^0.14.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.0.0",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,9 +4,16 @@ import { ProductListComponent } from './components/product-list/product-list.com
 import { ProductDetailComponent } from './components/product-detail/product-detail.component';
 import { CartComponent } from './components/cart/cart.component';
 import { CheckoutComponent } from './components/checkout/checkout.component';
+import { LoginComponent } from './components/login/login.component';
+import { RoomTableComponent } from './components/room-table/room-table.component';
+import { OrderComponent } from './components/order/order.component';
+import { AuthGuard } from './services/auth.guard';
 
 const routes: Routes = [
-  { path: '', component: ProductListComponent },
+  { path: '', redirectTo: 'login', pathMatch: 'full' },
+  { path: 'login', component: LoginComponent },
+  { path: 'rooms', component: RoomTableComponent, canActivate: [AuthGuard] },
+  { path: 'order', component: OrderComponent, canActivate: [AuthGuard] },
   { path: 'product/:id', component: ProductDetailComponent },
   { path: 'cart', component: CartComponent },
   { path: 'checkout', component: CheckoutComponent }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,3 +2,4 @@
 <div class="container">
   <router-outlet></router-outlet>
 </div>
+<app-screen-lock></app-screen-lock>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
 
 import { AppComponent } from './app.component';
@@ -11,6 +11,10 @@ import { CartComponent } from './components/cart/cart.component';
 import { CheckoutComponent } from './components/checkout/checkout.component';
 import { CategoryFilterComponent } from './components/category-filter/category-filter.component';
 import { CategoryPipe } from './pipes/category.pipe';
+import { LoginComponent } from './components/login/login.component';
+import { RoomTableComponent } from './components/room-table/room-table.component';
+import { OrderComponent } from './components/order/order.component';
+import { ScreenLockComponent } from './components/screen-lock/screen-lock.component';
 
 @NgModule({
   declarations: [
@@ -21,11 +25,16 @@ import { CategoryPipe } from './pipes/category.pipe';
     CartComponent,
     CheckoutComponent,
     CategoryFilterComponent,
-    CategoryPipe
+    CategoryPipe,
+    LoginComponent,
+    RoomTableComponent,
+    OrderComponent,
+    ScreenLockComponent
   ],
   imports: [
     BrowserModule,
     ReactiveFormsModule,
+    FormsModule,
     AppRoutingModule
   ],
   providers: [],

--- a/src/app/components/header/header.component.css
+++ b/src/app/components/header/header.component.css
@@ -15,3 +15,7 @@ nav a {
   margin-right: 1rem;
   text-decoration: none;
 }
+
+nav button {
+  margin-right: 1rem;
+}

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,6 +1,9 @@
-<header>
+<header *ngIf="sessionService.isSessionOpen()">
   <nav>
-    <a routerLink="/">Home</a>
-    <a routerLink="/cart">Cart ({{ cartService.items.length }})</a>
+    <a routerLink="/rooms">Rooms</a>
+    <a routerLink="/order">Order</a>
+    <span>Cart ({{ cartService.items.length }})</span>
+    <button (click)="lock()">Lock</button>
+    <button (click)="closeSession()" routerLink="/login">Close</button>
   </nav>
 </header>

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { CartService } from '../../services/cart.service';
+import { SessionService } from '../../services/session.service';
 
 @Component({
   selector: 'app-header',
@@ -7,5 +8,13 @@ import { CartService } from '../../services/cart.service';
   styleUrls: ['./header.component.css']
 })
 export class HeaderComponent {
-  constructor(public cartService: CartService) {}
+  constructor(public cartService: CartService, public sessionService: SessionService) {}
+
+  lock(): void {
+    this.sessionService.lock();
+  }
+
+  closeSession(): void {
+    this.sessionService.closeSession();
+  }
 }

--- a/src/app/components/login/login.component.css
+++ b/src/app/components/login/login.component.css
@@ -1,0 +1,20 @@
+.login-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #fff;
+  color: #333;
+}
+
+input {
+  display: block;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  width: 200px;
+}
+
+button {
+  padding: 0.5rem 1rem;
+}

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -1,0 +1,8 @@
+<div class="login-container">
+  <h2>Cashier Login</h2>
+  <form (ngSubmit)="login()" #loginForm="ngForm">
+    <input type="text" placeholder="ID" [(ngModel)]="cashierId" name="id" required>
+    <input type="password" placeholder="PIN" [(ngModel)]="pin" name="pin" required>
+    <button type="submit" [disabled]="!loginForm.form.valid">Open Session</button>
+  </form>
+</div>

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { SessionService } from '../../services/session.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css']
+})
+export class LoginComponent {
+  cashierId = '';
+  pin = '';
+
+  constructor(private sessionService: SessionService, private router: Router) {}
+
+  login(): void {
+    if (this.cashierId && this.pin) {
+      this.sessionService.openSession(this.cashierId, this.pin);
+      this.router.navigate(['/rooms']);
+    }
+  }
+}

--- a/src/app/components/order/order.component.css
+++ b/src/app/components/order/order.component.css
@@ -1,0 +1,12 @@
+.order-page {
+  display: flex;
+}
+.catalog {
+  flex: 2;
+  padding: 1rem;
+}
+.cart-panel {
+  flex: 1;
+  padding: 1rem;
+  background: #f9f9f9;
+}

--- a/src/app/components/order/order.component.html
+++ b/src/app/components/order/order.component.html
@@ -1,0 +1,9 @@
+<div class="order-page">
+  <div class="catalog">
+    <app-category-filter (categorySelected)="onCategorySelected($event)"></app-category-filter>
+    <app-product-list [selectedCategory]="selectedCategory"></app-product-list>
+  </div>
+  <div class="cart-panel">
+    <app-cart></app-cart>
+  </div>
+</div>

--- a/src/app/components/order/order.component.ts
+++ b/src/app/components/order/order.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { SessionService } from '../../services/session.service';
+
+@Component({
+  selector: 'app-order',
+  templateUrl: './order.component.html',
+  styleUrls: ['./order.component.css']
+})
+export class OrderComponent {
+  selectedCategory: string | null = null;
+
+  constructor(public sessionService: SessionService) {}
+
+  onCategorySelected(cat: string | null) {
+    this.selectedCategory = cat;
+  }
+}

--- a/src/app/components/product-list/product-list.component.html
+++ b/src/app/components/product-list/product-list.component.html
@@ -1,4 +1,3 @@
-<app-category-filter (categorySelected)="selectedCategory = $event"></app-category-filter>
 <div class="products">
   <div class="product" *ngFor="let product of products | category:selectedCategory">
     <img [src]="product.image" alt="{{product.name}}" />

--- a/src/app/components/product-list/product-list.component.ts
+++ b/src/app/components/product-list/product-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { ProductService } from '../../services/product.service';
 import { CartService } from '../../services/cart.service';
 import { Product } from '../../models/product';
@@ -10,7 +10,7 @@ import { Product } from '../../models/product';
 })
 export class ProductListComponent implements OnInit {
   products: Product[] = [];
-  selectedCategory: string | null = null;
+  @Input() selectedCategory: string | null = null;
 
   constructor(
     private productService: ProductService,

--- a/src/app/components/room-table/room-table.component.css
+++ b/src/app/components/room-table/room-table.component.css
@@ -1,0 +1,10 @@
+.rooms {
+  padding: 1rem;
+}
+.room {
+  margin-bottom: 1rem;
+}
+.tables button {
+  margin: 0.25rem;
+  padding: 1rem;
+}

--- a/src/app/components/room-table/room-table.component.html
+++ b/src/app/components/room-table/room-table.component.html
@@ -1,0 +1,8 @@
+<div class="rooms">
+  <div *ngFor="let room of rooms" class="room">
+    <h3>{{ room.name }}</h3>
+    <div class="tables">
+      <button *ngFor="let table of room.tables" (click)="selectTable(table.id)">{{ table.name }}</button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/room-table/room-table.component.ts
+++ b/src/app/components/room-table/room-table.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { rooms } from '../../mock/rooms';
+import { SessionService } from '../../services/session.service';
+
+@Component({
+  selector: 'app-room-table',
+  templateUrl: './room-table.component.html',
+  styleUrls: ['./room-table.component.css']
+})
+export class RoomTableComponent {
+  rooms = rooms;
+
+  constructor(private sessionService: SessionService, private router: Router) {}
+
+  selectTable(tableId: string): void {
+    this.sessionService.setTable(tableId);
+    this.router.navigate(['/order']);
+  }
+}

--- a/src/app/components/screen-lock/screen-lock.component.css
+++ b/src/app/components/screen-lock/screen-lock.component.css
@@ -1,0 +1,17 @@
+.lock-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255,255,255,0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.lock-dialog {
+  background: #fff;
+  padding: 2rem;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}

--- a/src/app/components/screen-lock/screen-lock.component.html
+++ b/src/app/components/screen-lock/screen-lock.component.html
@@ -1,0 +1,7 @@
+<div class="lock-overlay" *ngIf="sessionService.isLocked()">
+  <div class="lock-dialog">
+    <h3>Screen Locked</h3>
+    <input type="password" [(ngModel)]="pin" placeholder="Enter PIN">
+    <button (click)="unlock()">Unlock</button>
+  </div>
+</div>

--- a/src/app/components/screen-lock/screen-lock.component.ts
+++ b/src/app/components/screen-lock/screen-lock.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { SessionService } from '../../services/session.service';
+
+@Component({
+  selector: 'app-screen-lock',
+  templateUrl: './screen-lock.component.html',
+  styleUrls: ['./screen-lock.component.css']
+})
+export class ScreenLockComponent {
+  pin = '';
+
+  constructor(public sessionService: SessionService) {}
+
+  unlock(): void {
+    if (this.sessionService.unlock(this.pin)) {
+      this.pin = '';
+    } else {
+      alert('Wrong PIN');
+    }
+  }
+}

--- a/src/app/mock/rooms.ts
+++ b/src/app/mock/rooms.ts
@@ -1,0 +1,20 @@
+import { Room } from '../models/room';
+
+export const rooms: Room[] = [
+  {
+    id: 'room1',
+    name: 'Main Hall',
+    tables: [
+      { id: 't1', name: 'Table 1' },
+      { id: 't2', name: 'Table 2' }
+    ]
+  },
+  {
+    id: 'room2',
+    name: 'Patio',
+    tables: [
+      { id: 't3', name: 'Table 3' },
+      { id: 't4', name: 'Table 4' }
+    ]
+  }
+];

--- a/src/app/models/room.ts
+++ b/src/app/models/room.ts
@@ -1,0 +1,10 @@
+export interface Table {
+  id: string;
+  name: string;
+}
+
+export interface Room {
+  id: string;
+  name: string;
+  tables: Table[];
+}

--- a/src/app/services/auth.guard.ts
+++ b/src/app/services/auth.guard.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { SessionService } from './session.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private sessionService: SessionService, private router: Router) {}
+
+  canActivate(): boolean {
+    if (this.sessionService.isSessionOpen()) {
+      return true;
+    }
+    this.router.navigate(['/login']);
+    return false;
+  }
+}

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SessionService {
+  private cashierId: string | null = null;
+  private pin: string | null = null;
+  private currentTableId: string | null = null;
+  private locked = false;
+
+  openSession(id: string, pin: string): void {
+    this.cashierId = id;
+    this.pin = pin;
+    this.locked = false;
+  }
+
+  closeSession(): void {
+    this.cashierId = null;
+    this.pin = null;
+    this.currentTableId = null;
+    this.locked = false;
+  }
+
+  isSessionOpen(): boolean {
+    return this.cashierId !== null;
+  }
+
+  setTable(tableId: string): void {
+    this.currentTableId = tableId;
+  }
+
+  getTable(): string | null {
+    return this.currentTableId;
+  }
+
+  lock(): void {
+    this.locked = true;
+  }
+
+  isLocked(): boolean {
+    return this.locked;
+  }
+
+  unlock(pin: string): boolean {
+    if (this.pin === pin) {
+      this.locked = false;
+      return true;
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Add session service with login, table selection, and screen lock
- Create login, room/table, and order pages
- Update header and routing for multi-page POS flow

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: ng: not found)


------
https://chatgpt.com/codex/tasks/task_e_689b20de739483229eea7f3303d54154